### PR TITLE
Free tooltip now never flips over

### DIFF
--- a/src/lib/cyTooltips.js
+++ b/src/lib/cyTooltips.js
@@ -581,6 +581,14 @@ export default class cyTooltips {
                     'y': position.y * this.cy.zoom() + this.cy.pan().y
                 };
             }.bind(this),
+            popper: {
+                modifiers: [
+                    {
+                        name: 'flip',
+                        enabled: false,
+                    },
+                ],
+            }
         });
 
         tooltip = popperRefObj.state.elements.popper;


### PR DESCRIPTION
The tooltip now never flips over when approaching the edge of the container.